### PR TITLE
Fix WebXR referenceSpace error

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -62,6 +62,7 @@ function init() {
 			'plane-detection',
 			'hit-test',
 			'mesh-detection',
+			'local-floor'
 		],
 		onUnsupported: () => {
 			arButton.style.display = 'none';

--- a/example/index.js
+++ b/example/index.js
@@ -62,7 +62,7 @@ function init() {
 			'plane-detection',
 			'hit-test',
 			'mesh-detection',
-			'local-floor'
+			'local-floor',
 		],
 		onUnsupported: () => {
 			arButton.style.display = 'none';


### PR DESCRIPTION
This change avoids this error seen on entering AR:

`DOMException: Failed to execute 'requestReferenceSpace' on 'XRSession': This device does not support the requested reference space type.`

See #4 

Problem seen & fix tested on a Quest Pro.  Browser version 29.1.0.14.88.521409580.

Presumably this problem didn't exist in the past?  This is the first time I have tested the example app, so I can't tell for sure...
