### PR TITLE
Clean up stale state on detection of change of session

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -80,6 +80,8 @@ function init() {
 	controller.addEventListener('disconnected', function () {
 		this.remove(this.children[0]);
 		this.gamepadWrapper = null;
+		ratk.deleteHitTestTarget(this.hitTestTarget)
+		this.hitTestTarget = null;
 	});
 	scene.add(controller);
 
@@ -178,6 +180,10 @@ function render() {
 		}, 1000);
 
 		recoveredPersistentAnchors = true;
+	}
+
+	if (renderer.xr.isPresenting) {
+		recoveredPersistentAnchors = false;
 	}
 
 	updateController(controller);

--- a/src/RealityAccelerator.ts
+++ b/src/RealityAccelerator.ts
@@ -35,6 +35,8 @@ export class RealityAccelerator {
 
 	private _root: Group;
 
+	private _currentSession: XRSession;
+
 	public constructor(xrManager: WebXRManager) {
 		this._xrManager = xrManager;
 		this._planes = new Set();
@@ -42,6 +44,7 @@ export class RealityAccelerator {
 		this._anchors = new Set();
 		this._hitTestTargets = new Set();
 		this._root = new Group();
+		this._currentSession = xrManager.getSession();
 	}
 
 	get root() {
@@ -82,6 +85,12 @@ export class RealityAccelerator {
 		if (!this._xrManager.isPresenting) return;
 		const frame = this._xrManager.getFrame();
 
+		const session = this._xrManager.getSession();
+		if (session !== this._currentSession) {
+			this._currentSession = session;
+			this._sessionUpdated()
+		}
+
 		this._checkPlaneDiff(frame);
 
 		this.planes.forEach((plane) => {
@@ -100,6 +109,19 @@ export class RealityAccelerator {
 
 		this._hitTestTargets.forEach((hitTestTarget) => {
 			updateHitTestTarget(hitTestTarget, this._xrManager);
+		});
+	}
+
+	private async _sessionUpdated() {
+
+		this._anchors.forEach((anchor) => {
+			this._anchors.delete(anchor);
+			this._root.remove(anchor);
+		})
+
+		this._hitTestTargets.forEach((hitTestTarget) => {
+			this._root.remove(hitTestTarget);
+			this._hitTestTargets.delete(hitTestTarget);
 		});
 	}
 


### PR DESCRIPTION
Proposed fix for #8

- On existing and re-entering immersive mode, the Anchors created/restored and HitTestTargets created will have been lost from the XRSession.  Therefore ratk should clear up it's internal representation of these objects to match the current XRSession.

- The test application must re-call `restorePersistentAnchors()` each time a new XRSession begins.

- The test application should remove HitTestTargets created for a give controller when that controller is disconnected.  

(Technically, given the change to ratk above to discard stale HitTestTargets, this last change is not required for the scenario described in #8, but it would be required for scenarios where the controller disconnects and re-connects without a change of session)